### PR TITLE
Force ordering of authors in flaky post#as_json test and presenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you have added these scripts to your PATH you can leave off "bin-docker/" in 
 Once you've taken these steps, you should be able to set up the contents of the glowfic database with some example data:
 *   `bin-docker/rake db:setup`
 
-This will set up the database and add some sample information – currently these are users, continuities, characters, galleries, icons and templates; no posts will be created.
+This will set up the database and add some sample information – currently these are users, continuities, characters, galleries, icons and templates, and some posts and replies.
 
 If you encounter an error involving the 'citext' extension:
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -51,7 +51,7 @@ class Tag < ApplicationRecord
 
     g_tags = gallery_tags.joins(:gallery)
     g_tags = g_tags.where(galleries: { user_id: options[:user_id] }) if options[:user_id].present?
-    tag_json[:gallery_ids] = g_tags.pluck(:gallery_id)
+    tag_json[:gallery_ids] = g_tags.pluck(:gallery_id).sort
     tag_json
   end
 

--- a/app/presenters/character_presenter.rb
+++ b/app/presenters/character_presenter.rb
@@ -19,7 +19,7 @@ class CharacterPresenter
 
     char_json[:selector_name] = character.selector_name if options[:include].include?(:selector_name)
     char_json[:default_icon] = character.default_icon.try(:as_json) if options[:include].include?(:default_icon)
-    char_json[:aliases] = character.aliases if options[:include].include?(:aliases)
+    char_json[:aliases] = character.aliases.ordered if options[:include].include?(:aliases)
     char_json[:nickname] = character.nickname if options[:include].include?(:nickname)
     return char_json unless options[:include].include?(:galleries)
 
@@ -36,13 +36,13 @@ class CharacterPresenter
     galleries.map do |gallery|
       {
         name: gallery.name,
-        icons: gallery.icons,
+        icons: gallery.icons.ordered,
       }
     end
   end
 
   def single_gallery_json
-    icons = character.icons
+    icons = character.icons.ordered
     icons |= [character.default_icon] if character.default_icon.present?
     return [] unless icons.present?
     [{ icons: icons }]

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -23,7 +23,7 @@ class PostPresenter
     post_json.merge({
       board: post.board,
       section: post.section,
-      authors: post.joined_authors,
+      authors: post.joined_authors.ordered,
       num_replies: post.reply_count,
     })
   end

--- a/bin-docker/backstop
+++ b/bin-docker/backstop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin-docker/bundle
+++ b/bin-docker/bundle
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bundle "$@"

--- a/bin-docker/psql
+++ b/bin-docker/psql
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm postgres psql "$@"

--- a/bin-docker/rails
+++ b/bin-docker/rails
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bin/rails $@

--- a/bin-docker/rake
+++ b/bin-docker/rake
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web rake "$@"

--- a/bin-docker/record_examples
+++ b/bin-docker/record_examples
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm -e "APIPIE_RECORD=examples" web bundle exec rspec spec/controllers/api

--- a/bin-docker/rspec
+++ b/bin-docker/rspec
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web bundle exec rspec "$@"

--- a/bin-docker/runner
+++ b/bin-docker/runner
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker compose run --rm web "$@"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1135,9 +1135,9 @@ RSpec.describe Post do
     end
 
     context "with complex post" do
-      let(:author) { create(:user) }
-      let(:coauthor) { create(:user) }
-      let(:unjoined) { create(:user) }
+      let(:author) { create(:user, username: "Author") }
+      let(:coauthor) { create(:user, username: "Coauthor") }
+      let(:unjoined) { create(:user, username: "Unjoined") }
       let(:board) { create(:board) }
       let(:section) { create(:board_section, board: board) }
       let(:character) { create(:character, user: author, screenname: 'testing_home') }
@@ -1159,7 +1159,7 @@ RSpec.describe Post do
           id: post.id,
           subject: post.subject,
           description: 'test description',
-          authors: [author, coauthor],
+          authors: [author, coauthor], # alphabetical order by username
           board: board,
           section: section,
           section_order: 0,


### PR DESCRIPTION
match_hash sorts the array (.sort) and the relation (.ordered) but they
use different ordering techniques and diverge in their result when the
username crosses a power of ten (e.g. JohnDoe999 and JohnDoe1001).

We also force more ordering in presenters.
This likely isn't super relevant to API clients, but at least we
hopefully won't change output unnecessarily based on arbitrary database
ordering!